### PR TITLE
Add version info to hyper_promp init file.

### DIFF
--- a/hyper_prompt/__init__.py
+++ b/hyper_prompt/__init__.py
@@ -1,0 +1,3 @@
+"""Hyper prompt."""
+
+__version__ = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,12 @@ setup(
     install_requires=[
         "argparse",
     ],
+    extras_require={
+        'develop':[
+            'pytest',
+            'pytest-cov'
+        ]
+    },
     entry_points="""
     [console_scripts]
     hyper-prompt=hyper_prompt.cli:main


### PR DESCRIPTION
Fixes the following traceback


```
 ❯ hyper-prompt --version                                                                                                                              [12:40:10]
Traceback (most recent call last):
  File "/.../hyper-prompt/venv/bin/hyper-prompt", line 11, in <module>
    load_entry_point('hyper-prompt==0.1.0', 'console_scripts', 'hyper-prompt')()
  File "build/bdist.macosx-10.13-x86_64/egg/hyper_prompt/cli.py", line 97, in main
AttributeError: 'module' object has no attribute '__version__'
```

- Additionally fixed setup.py to consider pytest and pytest-cov as extra dependencies.